### PR TITLE
potential final draft for issue #24

### DIFF
--- a/data_reports/128_WorldwideSCND.Rmd
+++ b/data_reports/128_WorldwideSCND.Rmd
@@ -108,12 +108,22 @@ dataset_layer <- standardCast(dataset_layer)
 ## Running Summaries to Make Sure Only Duplicates Were Removed
 
 ```{r}
-length(summary(as.factor(as.character(dataset_profile_org$profile_name)), maxsum = 22000))
-#To guarantee that only duplicates were removed, the value of unique dataset_profile_org$profile_name should be the same amount of objects as dataset_profile
-#4357 = 4357
-length(summary(as.factor(as.character(dataset_layer_org$layer_name)), maxsum = 22000))
-#To guarantee that only duplicates were removed, the value of unique dataset_layer_org$layer_name should be the same amount of objects as dataset_layer
-#21736 != 21739
+#the numbers calculated should equal the number of objects in the both dataset_profile and dataset_layer
+
+dataset_profile %>%
+  group_by(profile_name, site_name, dataset_name_sub) %>%
+  tally() %>%
+  #filter(n > 1) #this pulls out duplicate rows
+  nrow() #this returns the number of rows in the unique table
+
+dataset_layer %>%
+  group_by(layer_name, profile_name, site_name, dataset_name_sub) %>%
+  tally() %>%
+  #filter(n > 1) #this pulls out duplicate rows
+  nrow() #this returns the number of rows in the unique table 
+
+#dataset_layer %>% #use this to pull specific layers
+#  filter(layer_name %in% c("100002.1", "100003.1", "100004.1" ))
 ```
 
 ```{r message=FALSE, warning=FALSE}
@@ -235,7 +245,6 @@ ggplot(dataset_layer %>%
 ## TODO
 
 - download and re-ingest from 10.3334/CDIAC/lue.ndp018
-- Commit and link the commit to the issue
 
 ## Citations
 

--- a/data_reports/128_WorldwideSCND.Rmd
+++ b/data_reports/128_WorldwideSCND.Rmd
@@ -1,8 +1,8 @@
 # Worldwide soil carbon and nitrogen data
 
-The `Worldwide soil carbon and nitrogen data` data set in ISCN3 contains `r nrow(dataset_layer)` layer-level information and `r nrow(dataset_profile)` profile-level information after cleaning for ISCN3.5.
-In dataset_profile, three columns were removed due to being SOC calculated and 5287 rows were removed due to being duplicate rows (unique function was applied). 
-In dataset_layer, four columns were removed due to being SOC calculated and 233 rows were removed due to being duplicate rows (unique function was applied).
+The `Worldwide soil carbon and nitrogen data` data set in ISCN3 contains 21739 layer-level rows and 4357 profile-level information rows after cleaning for ISCN3.5.
+Rows were removed from ISCN3 due to being duplicates (a unique function was applied).
+Columns were removed from ISCN3 if they were SOC calculated.
 
 
 ```{r warning=FALSE, message=FALSE}

--- a/data_reports/128_WorldwideSCND.Rmd
+++ b/data_reports/128_WorldwideSCND.Rmd
@@ -1,17 +1,12 @@
 # Worldwide soil carbon and nitrogen data
 
-The `Worldwide soil carbon and nitrogen data` data set in ISCN3 contains XX layer-level rows and YY profile-level information rows after cleaning for ISCN3.5.
-Rows were/weren't removed from ISCN3 because of reasons.
-Columns were/weren't removed from ISCN3 because of reasons.
-Values in columns were reassigned to XX because of reasons.
-
 The `Worldwide soil carbon and nitrogen data` data set in ISCN3 contains `r nrow(dataset_layer)` layer-level information and `r nrow(dataset_profile)` profile-level information after cleaning for ISCN3.5.
 In dataset_profile, three columns were removed due to being SOC calculated and 5287 rows were removed due to being duplicate rows (unique function was applied). 
 In dataset_layer, four columns were removed due to being SOC calculated and 233 rows were removed due to being duplicate rows (unique function was applied).
 
 
 ```{r warning=FALSE, message=FALSE}
-datasetName <- "Worldwide soil carbon and nitrogen data" #fix this
+datasetName <- "Worldwide soil carbon and nitrogen data"
 
 ##### Extract the study information ####
 dataset_study <- citation_raw %>% 
@@ -110,6 +105,16 @@ dataset_layer <- standardCast(dataset_layer)
 
 ```
 
+## Running Summaries to Make Sure Only Duplicates Were Removed
+
+```{r}
+length(summary(as.factor(as.character(dataset_profile_org$profile_name)), maxsum = 22000))
+#To guarantee that only duplicates were removed, the value of unique dataset_profile_org$profile_name should be the same amount of objects as dataset_profile
+#4357 = 4357
+length(summary(as.factor(as.character(dataset_layer_org$layer_name)), maxsum = 22000))
+#To guarantee that only duplicates were removed, the value of unique dataset_layer_org$layer_name should be the same amount of objects as dataset_layer
+#21736 != 21739
+```
 
 ```{r message=FALSE, warning=FALSE}
 knitr::kable(t(dataset_study))


### PR DESCRIPTION
I found a way to count the number of duplicates for larger datasets (line 110 of data_reports/128_WorldwideSCND.Rmd) that worked for the dataset_profile

However, for the dataset_layer it shows that three rows were not removed and I'm not sure of the error.
This last tweak will leave the data report complete and ready for merging.